### PR TITLE
Remove build steps for extras

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,6 @@ include(appInfo.cmake)
 # Build and install main executable
 add_subdirectory(rhubarb)
 
-# Build and install extras
-add_subdirectory("extras/AdobeAfterEffects")
-add_subdirectory("extras/MagixVegas")
-add_subdirectory("extras/EsotericSoftwareSpine")
-
 # Install misc. files
 install(
 	FILES README.adoc LICENSE.md CHANGELOG.md


### PR DESCRIPTION
I've forked this project to edit the make file so that it does not build the "extras". The extras allow integrations into third party software and at least one of them has Java as a dependency. Not that Java is bad, but it's one extra thing to maintain and configure. Also, we don't use any of the integrations, just the command line tool. Which I'm currently building a npm api wrapper for.
